### PR TITLE
⛽ feat: add log retention configuration for ZooKeeper and delete segment directories

### DIFF
--- a/roles/controller/templates/controller-conf.j2
+++ b/roles/controller/templates/controller-conf.j2
@@ -10,6 +10,7 @@ controller.tenant.isolation.enable={{ controller_tenant_isolation_enable }}
 
 controller.allow.hlc.tables=false
 controller.enable.split.commit=true
+controller.deleted.segments.retentionInDays=1
 controller.realtime.segment.deepStoreUploadRetryEnabled=true
 
 # Create users "admin" and "user". Keep in mind we're not enforcing any ACLs yet.

--- a/roles/zookeeper/defaults/main.yml
+++ b/roles/zookeeper/defaults/main.yml
@@ -3,3 +3,6 @@ zookeeper_image_name: zookeeper
 zookeeper_image_version: 3.8.0-temurin
 zookeeper_host_data_dir: ./data/zookeeper_data
 zookeeper_host_data_log_dir: ./data/zookeeper_data_log
+zookeeper_log4j_prop: "WARN,ROLLINGFILE"
+zookeeper_autopurge_purgeinterval: 1   # This value is based on day number
+zookeeper_autopurge_snapretaincount: 10 

--- a/roles/zookeeper/templates/zookeeper-compose.j2
+++ b/roles/zookeeper/templates/zookeeper-compose.j2
@@ -16,8 +16,10 @@ services:
       ZOO_SERVERS: {% for item in zk_hosts %}
 server.{{ hostvars[item | quote]['ansible_host'].split('.')[-1] }}={{hostvars[item | quote]['ansible_host'] if hostvars[item | quote]['ansible_host'] != current_host else '0.0.0.0'}}:2888:3888;2181{{- " " if not loop.last else "" -}} 
 {%- endfor %}      
-      ZOO_LOG4J_PROP: 
+      ZOO_LOG4J_PROP: {{ zookeeper_log4j_prop }}
       ZOO_4LW_COMMANDS_WHITELIST:  "*"
+      ZOO_AUTOPURGE_PURGEINTERVAL: {{ zookeeper_autopurge_purgeinterval }}
+      ZOO_AUTOPURGE_SNAPRETAINCOUNT: {{ zookeeper_autopurge_snapretaincount }}
     volumes:
       - {{ zookeeper_host_data_dir }}:/data
       - {{ zookeeper_host_data_log_dir }}:/datalog


### PR DESCRIPTION
This pull request adds log retention configuration for the ZooKeeper data logs directory and the Delete Segment directory in the Pinot controller. Previously, these directories did not have log retention settings, which could lead to excessive disk usage and performance issues over time